### PR TITLE
test-w3c: initialize glog framework earlier

### DIFF
--- a/test/src/test-w3c.cpp
+++ b/test/src/test-w3c.cpp
@@ -107,10 +107,10 @@ int main(int argc, char** argv) {
 			exit(EXIT_FAILURE);
 		}
 
-		HTTPServer::getInstance(32954, 32955, NULL); // bind to some random tcp sockets for ioprocessor tests
-
 		google::InitGoogleLogging(argv[0]);
 		google::LogToStderr();
+
+		HTTPServer::getInstance(32954, 32955, NULL); // bind to some random tcp sockets for ioprocessor tests
 
 		char* dfEnv = getenv("USCXML_DELAY_FACTOR");
 		if (dfEnv) {


### PR DESCRIPTION
In test-w3c.cpp HTTP::getInstance was called before the Google logging framework was initialized. Since HTTP::getInstance already writes informations to the log, the following warning was generated:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
```

This warning is avoided by initializing the Google logging framework first.
