### PR TITLE
Add missing include, add diagnostic functions

### DIFF
--- a/src/uscxml/plugins/invoker/im/IMInvoker.cpp
+++ b/src/uscxml/plugins/invoker/im/IMInvoker.cpp
@@ -21,6 +21,7 @@
 #include <glog/logging.h>
 #include "uscxml/UUID.h"
 #include "uscxml/dom/DOMUtils.h"
+#include "uscxml/dom/NameSpacingParser.h"
 #include <boost/algorithm/string.hpp>
 
 #include "uscxml/concurrency/DelayedEventQueue.h"


### PR DESCRIPTION
This patch adds a missing include directive, otherwise uscxml won't compile. Further two functions are added to the Interpreter. One returns all valid events which lead to a transition, another returns a list of the corresponding targets. Return values are std::vector<std::string>