### PR TITLE
Problem: When libevent is built by uscxml, test-gen-c doesn't wait for it being built

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,6 +110,10 @@ add_executable(test-gen-c
 	${GETOPT_FILES})
 target_link_libraries(test-gen-c ${LIBEVENT_LIBRARIES})
 
+if (USCXML_PREREQS)
+    add_dependencies(test-gen-c ${USCXML_PREREQS})
+endif()
+
 if (WIN32)
 	target_link_libraries(test-gen-c Ws2_32)	
 endif()


### PR DESCRIPTION
Solution: add add_dependency..