### PR TITLE
[Lua datamodel] Correcting bug with mixed ordered tables and wrong foreach evaluation

### DIFF
--- a/src/uscxml/debug/DebuggerServlet.cpp
+++ b/src/uscxml/debug/DebuggerServlet.cpp
@@ -224,6 +224,7 @@ void DebuggerServlet::processListSessions(const HTTPServer::Request& request) {
 	Data replyData;
 
 	std::map<std::string, std::weak_ptr<InterpreterImpl> > instances = InterpreterImpl::getInstances();
+	int index = 0;
 	for (auto weakInstance : instances) {
 
 		std::shared_ptr<InterpreterImpl> instance = weakInstance.second.lock();
@@ -234,7 +235,7 @@ void DebuggerServlet::processListSessions(const HTTPServer::Request& request) {
 			sessionData.compound["source"] = Data(instance->getBaseURL(), Data::VERBATIM);
 			sessionData.compound["xml"].node = instance->getDocument();
 
-			replyData.compound["sessions"].array.push_back(sessionData);
+			replyData.compound["sessions"].array.insert(std::make_pair(index++,sessionData));
 		}
 	}
 

--- a/src/uscxml/interpreter/BasicDelayedEventQueue.cpp
+++ b/src/uscxml/interpreter/BasicDelayedEventQueue.cpp
@@ -192,7 +192,7 @@ Data BasicDelayedEventQueue::serialize() {
 	}
 
 	Data serialized;
-
+	int index = 0;
 	for (auto event : _queue) {
 		struct callbackData cb = _callbackData[event.uuid];
 
@@ -210,7 +210,7 @@ Data BasicDelayedEventQueue::serialize() {
 		delayedEvent["event"] = event;
 		delayedEvent["delay"] = Data(delayMs, Data::INTERPRETED);
 
-		serialized["BasicDelayedEventQueue"].array.push_back(event);
+		serialized["BasicDelayedEventQueue"].array.insert(std::make_pair(index++,event));
 	}
 
 	start();
@@ -221,8 +221,8 @@ void BasicDelayedEventQueue::deserialize(const Data& data) {
 	if (data.hasKey("BasicDelayedEventQueue")) {
 		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		for (auto event : data["BasicDelayedEventQueue"].array) {
-			Event e = Event::fromData(event["event"]);
-			enqueueDelayed(e, strTo<size_t>(event["delay"]), e.uuid);
+			Event e = Event::fromData(event.second["event"]);
+			enqueueDelayed(e, strTo<size_t>(event.second["delay"]), e.uuid);
 		}
 	}
 

--- a/src/uscxml/interpreter/BasicEventQueue.cpp
+++ b/src/uscxml/interpreter/BasicEventQueue.cpp
@@ -92,8 +92,9 @@ Data BasicEventQueue::serialize() {
 	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	Data serialized;
 
+	int index = 0;
 	for (auto event : _queue) {
-		serialized["BasicEventQueue"].array.push_back(event);
+		serialized["BasicEventQueue"].array.insert(std::make_pair(index++,event));
 	}
 	return serialized;
 }
@@ -102,7 +103,7 @@ void BasicEventQueue::deserialize(const Data& data) {
 	if (data.hasKey("BasicEventQueue")) {
 		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		for (auto event : data["BasicEventQueue"].array) {
-			_queue.push_back(Event::fromData(event));
+			_queue.push_back(Event::fromData(event.second));
 		}
 	}
 }

--- a/src/uscxml/interpreter/FastMicroStep.cpp
+++ b/src/uscxml/interpreter/FastMicroStep.cpp
@@ -294,16 +294,18 @@ void FastMicroStep::init(XERCESC_NS::DOMElement* scxml) {
 	auto endState = cache.compound["states"].array.end();
 #endif
 
+	int index = 0;
 	for (i = 0; i < _states.size(); i++) {
 #ifdef WITH_CACHE_FILES
 		Data* cachedState = NULL;
 		if (withCache) {
 			if (currState != endState) {
-				cachedState = &(*currState);
+				cachedState = &(currState->second);
 				currState++;
 			} else {
-				cache.compound["states"].array.push_back(Data());
-				cachedState = &(*cache.compound["states"].array.rbegin());
+				cache.compound["states"].array.insert(std::make_pair(index,Data()));
+				cachedState = &(cache.compound["states"].array[index]);
+				index++;
 			}
 		}
 #endif
@@ -448,17 +450,19 @@ COMPLETION_STABLISHED:
 	auto endTrans = cache.compound["transitions"].array.end();
 #endif
 
+	int index1 = 0;
 	for (i = 0; i < _transitions.size(); i++) {
 
 #ifdef WITH_CACHE_FILES
 		Data* cachedTrans = NULL;
 		if (withCache) {
 			if (currTrans != endTrans) {
-				cachedTrans = &(*currTrans);
+				cachedTrans = &(currTrans->second);
 				currTrans++;
 			} else {
-				cache.compound["transitions"].array.push_back(Data());
-				cachedTrans = &(*cache.compound["transitions"].array.rbegin());
+				cache.compound["transitions"].array.insert(std::make_pair(index1,Data()));
+				cachedTrans = &(cache.compound["transitions"].array[index1]);
+				index1++;
 			}
 		}
 #endif

--- a/src/uscxml/messages/Data.cpp
+++ b/src/uscxml/messages/Data.cpp
@@ -61,11 +61,7 @@ void Data::merge(const Data& other) {
 		if (array.size() == 0) {
 			array = other.array;
 		} else {
-			std::list<Data>::const_iterator arrIter = other.array.begin();
-			while(arrIter != other.array.end()) {
-				array.push_back(*arrIter);
-				arrIter++;
-			}
+			array.insert(other.array.begin(), other.array.end());
 		}
 	}
 	if (other.atom.size() > 0) {
@@ -147,6 +143,7 @@ Data Data::fromJSON(const std::string& jsonString) {
 	dataStack.push_back(&data);
 
 	size_t currTok = 0;
+	int index = 0;
 	do {
 		// used for debugging
 //		jsmntok_t t2 = t[currTok];
@@ -194,8 +191,9 @@ Data Data::fromJSON(const std::string& jsonString) {
 		}
 		if (tokenStack.back().type == JSMN_ARRAY) {
 			// push new index
-			dataStack.back()->array.push_back(Data());
-			dataStack.push_back(&(dataStack.back()->array.back()));
+			dataStack.back()->array.insert(std::make_pair(index,Data()));
+			dataStack.push_back(&dataStack.back()->array[index]);
+			index++;
 		}
 
 	} while (true);
@@ -248,14 +246,13 @@ std::string Data::toJSON(const Data& data) {
 
 		std::string seperator;
 		os << std::endl << indent << "[";
-		std::list<Data>::const_iterator arrayIter = data.array.begin();
-		while(arrayIter != data.array.end()) {
+		for (auto it : data.array) {
 			_dataIndentation += 1;
-			os << seperator << *arrayIter;
+			os << seperator << it.second;
 			_dataIndentation -= 1;
 			seperator = ", ";
-			arrayIter++;
 		}
+
 		os << "]";
 	} else if (data.atom.size() > 0) {
 		// empty string is handled below

--- a/src/uscxml/messages/Data.h
+++ b/src/uscxml/messages/Data.h
@@ -141,12 +141,7 @@ public:
 	}
 
 	Data& operator[](const size_t index) {
-		while(array.size() < index) {
-			array.push_back(Data("", Data::VERBATIM));
-		}
-		std::list<Data>::iterator arrayIter = array.begin();
-		for (size_t i = 0; i < index; i++, arrayIter++) {}
-		return *arrayIter;
+		return array.at(index);
 	}
 #endif
 
@@ -162,10 +157,9 @@ public:
 	}
 
 	const Data item(const size_t index) const {
-		if (array.size() > index) {
-			std::list<Data>::const_iterator arrayIter = array.begin();
-			for (size_t i = 0; i < index; i++, arrayIter++) {}
-			return *arrayIter;
+		auto it = array.find(index);
+		if (it != array.end()) {
+			return it->second;
 		}
 		Data data;
 		return data;
@@ -195,7 +189,7 @@ public:
 		return compound;
 	}
 
-	operator std::list<Data>() {
+	operator std::map<int,Data>() {
 		return array;
 	}
 
@@ -203,10 +197,10 @@ public:
 	static std::string toJSON(const Data& data);
 	std::string asJSON() const;
 
-	std::list<Data> getArray() {
+	std::map<int,Data> getArray() {
 		return array;
 	}
-	void setArray(const std::list<Data>& array) {
+	void setArray(const std::map<int,Data>& array) {
 		this->array = array;
 	}
 
@@ -247,7 +241,7 @@ protected:
 	XERCESC_NS::DOMNode* node;
 //	std::shared_ptr<XERCESC_NS::DOMDocument> adoptedDoc;
 	std::map<std::string, Data> compound;
-	std::list<Data> array;
+	std::map<int,Data> array;
 	std::string atom;
 	Blob binary;
 	Type type;

--- a/src/uscxml/messages/Event.cpp
+++ b/src/uscxml/messages/Event.cpp
@@ -48,7 +48,7 @@ Event Event::fromData(const Data& data) {
 
 	if (data.hasKey("params")) {
 		for (auto param : data["params"].array) {
-			e.params.insert(std::make_pair(param.compound.begin()->first, param.compound.begin()->second));
+			e.params.insert(std::make_pair(param.second.compound.begin()->first, param.second.compound.begin()->second));
 		}
 	}
 	return e;
@@ -68,10 +68,11 @@ Event::operator Data() {
 	data["uuid"] = Data(uuid, Data::VERBATIM);
 	data["namelist"].compound = namelist;
 
+	int index=0;
 	for (auto param : params) {
 		Data entry;
 		entry.compound[param.first] = param.second;
-		data["params"].array.push_back(entry);
+		data["params"].array.insert(std::make_pair(index++,entry));
 	}
 
 	return data;

--- a/src/uscxml/plugins/datamodel/lua/LuaDataModel.cpp
+++ b/src/uscxml/plugins/datamodel/lua/LuaDataModel.cpp
@@ -31,8 +31,6 @@
 
 #include "LuaBridge.h"
 
-#include <fstream>
-
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -78,6 +76,7 @@ static int luaEval(lua_State* luaState, const std::string& expr) {
 	return postStack - preStack;
 }
 
+/* Converts from C string to Lua string (analog of lua 'string.format("%q",s)' */
 static std::string strToLuaStr(std::string s_text) {
 	std::size_t s = 0;
 	while (s<s_text.size())
@@ -104,6 +103,7 @@ static std::string strToLuaStr(std::string s_text) {
 	return '"' + s_text + '"';
 }
 
+/* Serializer of LuaRef. Supports only simple types (nil, boolean, number, table, string). Tables are copied!!! No references! */
 static void convertLuaStateToChunk(const luabridge::LuaRef& lua, std::ostream &out) {
 	if (lua.isFunction()) {
 		// functions are not supported for serialization

--- a/src/uscxml/plugins/datamodel/lua/LuaDataModel.cpp
+++ b/src/uscxml/plugins/datamodel/lua/LuaDataModel.cpp
@@ -232,22 +232,23 @@ static luabridge::LuaRef getDataAsLua(lua_State* _luaState, const Data& data) {
 			return luaData;
 		}
 	}
-	if (data.compound.size() > 0) {
+	
+	// lua tables can be mixed!
+	// tmp = { [1]=1,[2]=2,["test"]=5 }
+	if (data.compound.size() > 0 || data.array.size() > 0) {
 		luaData = luabridge::newTable(_luaState);
+
+		std::list<Data>::const_iterator arrayIter = data.array.begin();
+		while (arrayIter != data.array.end()) {
+			luaData.append(getDataAsLua(_luaState, *arrayIter));
+			arrayIter++;
+		}
+
 		std::map<std::string, Data>::const_iterator compoundIter = data.compound.begin();
 		while(compoundIter != data.compound.end()) {
 			luaData[compoundIter->first] = getDataAsLua(_luaState, compoundIter->second);
 			compoundIter++;
-		}
-		return luaData;
-	}
-	if (data.array.size() > 0) {
-		luaData = luabridge::newTable(_luaState);
-		std::list<Data>::const_iterator arrayIter = data.array.begin();
-		while(arrayIter != data.array.end()) {
-			luaData.append(getDataAsLua(_luaState, *arrayIter));
-			arrayIter++;
-		}
+		}		
 		return luaData;
 	}
 	if (data.atom.size() > 0) {

--- a/src/uscxml/plugins/invoker/dirmon/DirMonInvoker.cpp
+++ b/src/uscxml/plugins/invoker/dirmon/DirMonInvoker.cpp
@@ -75,8 +75,9 @@ Data DirMonInvoker::getDataModelVariables() {
 	data.compound["dir"] = Data(_dir, Data::VERBATIM);
 
 	std::set<std::string>::iterator suffixIter = _suffixes.begin();
+	int index = 0;
 	while(suffixIter != _suffixes.end()) {
-		data.compound["suffixes"].array.push_back(Data(*suffixIter, Data::VERBATIM));
+		data.compound["suffixes"].array.insert(std::make_pair(index++,Data(*suffixIter, Data::VERBATIM)));
 		suffixIter++;
 	}
 

--- a/src/uscxml/server/HTTPServer.cpp
+++ b/src/uscxml/server/HTTPServer.cpp
@@ -334,10 +334,11 @@ void HTTPServer::httpRecvReqCallback(struct evhttp_request *req, void *callbackD
 	{
 		std::stringstream ss(request.data.compound["path"].atom);
 		std::string item;
+		int index = 0;
 		while(std::getline(ss, item, '/')) {
 			if (item.length() == 0)
 				continue;
-			request.data.compound["pathComponent"].array.push_back(Data(item, Data::VERBATIM));
+			request.data.compound["pathComponent"].array.insert(std::make_pair(index++,Data(item, Data::VERBATIM)));
 		}
 	}
 	// parse query string

--- a/src/uscxml/util/URL.cpp
+++ b/src/uscxml/util/URL.cpp
@@ -622,8 +622,9 @@ URLImpl::operator Data() const {
 
 	std::list<std::string> pathComps = pathComponents();
 	std::list<std::string>::const_iterator pathIter = pathComps.begin();
+	int index = 0;
 	while(pathIter != pathComps.end()) {
-		data.compound["pathComponent"].array.push_back(Data(*pathIter, Data::VERBATIM));
+		data.compound["pathComponent"].array.insert(std::make_pair(index++,Data(*pathIter, Data::VERBATIM)));
 		pathIter++;
 	}
 

--- a/test/issues/test-issua-lua-tables.scxml
+++ b/test/issues/test-issua-lua-tables.scxml
@@ -1,0 +1,70 @@
+
+<scxml datamodel="lua" initial="StateShape1" name="ScxmlShape1" version="1.0" xmlns="http://www.w3.org/2005/07/scxml">
+	<datamodel>
+		<data id="t_DifficultTable">{
+    [2] = {
+        [1]={ 5,5,5,5 },
+        [2]={ 5,5,5,5 },
+        [3]= { 10,10 }
+    },
+    [1] = {
+        [1]= { 4,4,4,4,4,4,4,4 },
+        [2]= { 8,8,8,8 },
+        [3]= { 16,16 }
+    },    
+    [3] = {
+        [1]={ 2,2,2 },
+        test = false,
+        good = true,
+        xxx = 'asdf'
+    },
+    zzz = {
+        1,2,3,&quot;different types&quot;,
+        [[bbbbbbb\nbbbbbb]],
+        qq = &quot;asdf 'asdf' [[asdf]]&quot;
+    }
+}
+		</data>
+		<data expr="{
+    [3]=3,
+    [2]=2,
+    [1]=1
+}" id="t_mixed"/>
+	</datamodel>
+	<state id="StateShape1">
+		<onentry>
+			<script>function PrintTable(t_val, s_tab)
+	if type(t_val)==&quot;table&quot; then
+		for k,v in pairs(t_val) do
+			print(string.format(&quot;%sk=%s[%s],v=%s[%s]&quot;,s_tab,tostring(k),type(k),tostring(v),type(v)))
+			PrintTable(v,s_tab .. &quot;\t&quot;)
+		end
+	end
+end
+
+PrintTable(t_DifficultTable,&quot;&quot;)
+			</script>
+			<foreach array="t_mixed" index="s_index" item="s_item">
+				<log expr="s_item" label="s_item"/>
+				<log expr="s_index" label="s_index"/>
+			</foreach>
+		</onentry>
+		<transition cond="t_DifficultTable[2][3][1]==10 and
+#t_DifficultTable[1]==3 and
+t_DifficultTable[3][1][2]==2 and
+t_DifficultTable[3].test==false and
+t_DifficultTable[3].xxx==&quot;asdf&quot; and
+t_DifficultTable.zzz.qq==&quot;asdf 'asdf' [[asdf]]&quot; and
+t_DifficultTable.zzz[1]==1 and
+t_DifficultTable.zzz[2]==2 and
+t_DifficultTable.zzz[3]==3 and
+t_DifficultTable.zzz[4]==&quot;different types&quot; and
+t_DifficultTable.zzz[5]==[[bbbbbbb\nbbbbbb]]" target="pass"/>
+		<transition event="error.*" target="fail"/>
+		<transition target="fail"/>
+	</state>
+	<final id="pass"/>
+	<final id="fail">
+		<onentry/>
+	</final>
+</scxml>


### PR DESCRIPTION
**Bug 1:** **lua boolean** type was not converted to **uscxml::Data**;
**Bug 2:** **lua table** was not correctly converted to **uscxml::Data**;

**Explanation:** 
1) mixed indexes must be correctly evaluated by foreach and during assigning
in old version it will be assigned in wrong order, because **we are dropping its actual lua index** during iteration
		`t_mixed_indexes = { [3]=3, [2]=2, [1]=1 }`
		`t_mixed_indexes = { [2]=2, [3]=3, [1]=1 }`
2) no garanty that even ordered table will be iterated propertly if we use 'lua_next'
		`t_no_garanty = { [1]=1, [2]=2 }`
                first iterator can be either 1 or 2 (depends on Lua version, compiler etc)
                correct way of iterating is only through indexes   
3) compatibility with Lua 5.1, 5.2, 5.3

**Solution:** convert table to lua chunk and to share with latest evaluation of it

P.S. All lua tests are passed and checked. And added special scxml for checking difficult tables with mixed ordering -  **test\issues\test-issua-lua-tables.scxml**