### PR TITLE
Problem: uscxml doesnt build because of missing include (gcc 7.3.1)

### DIFF
--- a/src/uscxml/interpreter/InterpreterMonitor.h
+++ b/src/uscxml/interpreter/InterpreterMonitor.h
@@ -25,6 +25,7 @@
 #include "uscxml/interpreter/Logging.h"
 #include "uscxml/debug/InterpreterIssue.h"
 
+#include <functional>
 #include <mutex>
 
 #define USCXML_MONITOR_CATCH(callback) \


### PR DESCRIPTION
Solution: add missing include to `functional`