### PR TITLE
add -o2 to scxmlcc test

### DIFF
--- a/contrib/benchmarks/run.sh
+++ b/contrib/benchmarks/run.sh
@@ -205,8 +205,8 @@ function run-scxmlcc {
 
 	cd scxmlcc
 	rm test
-	timeout ${TIMEOUT} ./scxmlcc/src/scxmlcc -i ${BENCHMARK} -o ./test.h
-	timeout ${TIMEOUT} g++ -DMACHINE_NAME=sc_benchmark ./statesPerSecond.cpp -o test
+	./scxmlcc/src/scxmlcc -i ${BENCHMARK} -o ./test.h
+	g++ -O2 -DMACHINE_NAME=sc_benchmark ./statesPerSecond.cpp -o test
 	timeout ${TIMEOUT} ./test |tee ../logs/${SC_NAME}-scxmlcc.log
 
 	cd ..


### PR DESCRIPTION
scxmlcc is designed to make the compiler able optimize away empty actions, etc.
For this to work, optimizations must be enabled, so the scxmlcc test program really should be compiled with -O2 when testing performance.