### PR TITLE
fix Xerces version bug in Ubuntu 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,14 +73,14 @@ if (APPLE)
 	set(LIBCPP_NAME "libstdc++") # before mavericks
 	# get MacOSX version
 	execute_process(
-		COMMAND /usr/bin/sw_vers -productVersion 
+		COMMAND /usr/bin/sw_vers -productVersion
 		OUTPUT_VARIABLE MACOSX_VERSION
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
 	if (MACOSX_VERSION)
 		THREE_PART_VERSION_TO_VARS(
 			${MACOSX_VERSION}
-			MACOSX_VERSION_MAJOR 
-			MACOSX_VERSION_MINOR 
+			MACOSX_VERSION_MAJOR
+			MACOSX_VERSION_MINOR
 			MACOSX_VERSION_PATCH)
 	endif()
 	if (MACOSX_VERSION VERSION_GREATER "10.8.99")
@@ -112,11 +112,11 @@ include_directories(${PROJECT_SOURCE_DIR}/contrib/src/jsmn)
 include_directories(${PROJECT_SOURCE_DIR}/contrib/src/evws)
 include_directories(${PROJECT_SOURCE_DIR}/contrib/src/uriparser/include)
 
-set(GETOPT_FILES ${PROJECT_SOURCE_DIR}/contrib/src/uscxml/InterpreterOptions.cpp)	
+set(GETOPT_FILES ${PROJECT_SOURCE_DIR}/contrib/src/uscxml/InterpreterOptions.cpp)
 if (WIN32)
 	include_directories(${PROJECT_SOURCE_DIR}/contrib/src/getopt)
 	include_directories(${PROJECT_SOURCE_DIR}/contrib/src/inttypes)
-	list(APPEND GETOPT_FILES ${PROJECT_SOURCE_DIR}/contrib/src/getopt/getopt.c)	
+	list(APPEND GETOPT_FILES ${PROJECT_SOURCE_DIR}/contrib/src/getopt/getopt.c)
 endif()
 
 ################################
@@ -143,7 +143,7 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
 
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall")
-	
+
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 	add_definitions("-D_SCL_SECURE_NO_WARNINGS")
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
@@ -289,9 +289,17 @@ else()
 endif()
 
 if (XercesC_FOUND)
+    if(${XercesC_VERSION} VERSION_LESS "3.2")
+	    set(XERCESC_NS "xercesc_3_1")
+        add_definitions(-DXERCESC_NS=xercesc_3_1)
+    elseif(${XercesC_VERSION} VERSION_LESS "3.3")
+	    set(XERCESC_NS "xercesc_3_2")
+        add_definitions(-DXERCESC_NS=xercesc_3_2)
+    else()
+        message(FATAL_ERROR "Incompatible version of XercesC; uSCXML supports 3.1 and 3.2")
+    endif()
 	include_directories(${XercesC_INCLUDE_DIRS})
 	list (APPEND USCXML_CORE_LIBS ${XercesC_LIBRARIES})
-	set(XERCESC_NS "xercesc_3_1")
 else()
 	message(STATUS "--> will download and compile")
 	include("${CMAKE_BUILD_SCRIPTS}/BuildXercesC.cmake")
@@ -300,6 +308,7 @@ else()
 		list (APPEND USCXML_CORE_LIBS ${XercesC_LIBRARIES})
 		list (APPEND USCXML_PREREQS xerces-c)
 		set(XERCESC_NS "xercesc_3_1")
+        add_definitions(-DXERCESC_NS=xercesc_3_1)
 	else()
 		message(FATAL_ERROR "Could neither find nor build XercesC")
 	endif()
@@ -383,7 +392,7 @@ if (WIN32)
 	file(GLOB POTENTIAL_SWIG "C:/Program Files/swig*" "C:/Program Files (x86)/swig*")
 	LIST(APPEND CMAKE_PROGRAM_PATH ${POTENTIAL_SWIG}) # swig.exe
 	# message(FATAL_ERROR "POTENTIAL_SWIG: ${POTENTIAL_SWIG}")
-	
+
 endif()
 LIST(APPEND CMAKE_PROGRAM_PATH $ENV{SWIG_DIR})
 find_package(SWIG)
@@ -430,7 +439,7 @@ if (WITH_DM_LUA)
 		# https://code.google.com/archive/p/luaforwindows/downloads
 		# https://github.com/rjpcomputing/luaforwindows/releases
 		set(ENV{LUA_DIR} "C:/Program Files (x86)/Lua/5.1/")
-		
+
 		# http://luabinaries.sourceforge.net/download.html
 		# set(ENV{LUA_DIR} "C:/Program Files (x86)/Lua/5.3/")
 	endif()
@@ -499,13 +508,13 @@ if (BUILD_AS_PLUGINS)
 	include_directories(${CMAKE_SOURCE_DIR}/contrib/src)
 	source_group("Plugins" FILES ${USCXML_PLUGINS})
 	list (APPEND USCXML_FILES ${USCXML_PLUGINS})
-	
+
 	add_library(uscxml ${USCXML_FILES})
 	target_link_libraries(uscxml ${USCXML_CORE_LIBS})
 	set_target_properties(uscxml PROPERTIES COMPILE_FLAGS "-DUSCXML_EXPORT")
 #	set_target_properties(uscxml PROPERTIES COMPILE_FLAGS "-DPLUMA_EXPORTS")
 	add_definitions(-DPLUMA_EXPORTS)
-else()	
+else()
 	add_library(uscxml ${USCXML_FILES})
 	target_link_libraries(uscxml ${USCXML_OPT_LIBS} ${USCXML_CORE_LIBS})
 endif()
@@ -585,10 +594,10 @@ foreach( FILE ${ALL_SOURCE_FILES} )
 	file(RELATIVE_PATH REL_PATH ${PROJECT_SOURCE_DIR} "${PATH}")
 	string(REGEX REPLACE "src/uscxml" "" REL_PATH "${REL_PATH}")
 	string(REGEX REPLACE "contrib/src" "contrib" REL_PATH "${REL_PATH}")
-	
+
 	string(REGEX REPLACE "^/" "" REL_PATH "${REL_PATH}") # leading slash
 	string(REGEX REPLACE "/" "\\\\" SRC_GROUP "${REL_PATH}") # escape /
-	
+
 	source_group("${SRC_GROUP}" FILES ${FILE})
 
 endforeach()

--- a/config.h.in
+++ b/config.h.in
@@ -46,7 +46,7 @@
 
 #cmakedefine V8_VERSION @V8_VERSION@
 
-// #cmakedefine XERCESC_NS @XERCESC_NS@
+#cmakedefine XERCESC_NS @XERCESC_NS@
 
 /** build type */
 #cmakedefine CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"

--- a/src/uscxml/Common.h
+++ b/src/uscxml/Common.h
@@ -20,7 +20,9 @@
 #ifndef COMMON_H_YZ3CIYP
 #define COMMON_H_YZ3CIYP
 
+#ifndef XERCESC_NS
 #define XERCESC_NS xercesc_3_1
+#endif
 
 #ifndef _MSC_VER
 #define ELPP_STACKTRACE_ON_CRASH 1

--- a/src/uscxml/interpreter/InterpreterImpl.cpp
+++ b/src/uscxml/interpreter/InterpreterImpl.cpp
@@ -75,7 +75,7 @@ void InterpreterImpl::addInstance(std::shared_ptr<InterpreterImpl> interpreterIm
 
 InterpreterImpl::InterpreterImpl() : _isInitialized(false), _document(NULL), _scxml(NULL), _state(USCXML_INSTANTIATED) {
 	try {
-		::xercesc_3_1::XMLPlatformUtils::Initialize();
+		::XERCESC_NS::XMLPlatformUtils::Initialize();
 	} catch (const XERCESC_NS::XMLException& toCatch) {
 		ERROR_PLATFORM_THROW("Cannot initialize XercesC: " + X(toCatch.getMessage()).str());
 	}
@@ -112,7 +112,7 @@ InterpreterImpl::~InterpreterImpl() {
 	}
 
 //    assert(_invokers.size() == 0);
-//    ::xercesc_3_1::XMLPlatformUtils::Terminate();
+//    ::XERCESC_NS::XMLPlatformUtils::Terminate();
 
 #ifdef WITH_CACHE_FILES
 	if (!envVarIsTrue("USCXML_NOCACHE_FILES") && _document != NULL) {

--- a/src/uscxml/interpreter/InterpreterMonitor.h
+++ b/src/uscxml/interpreter/InterpreterMonitor.h
@@ -26,6 +26,7 @@
 #include "uscxml/debug/InterpreterIssue.h"
 
 #include <mutex>
+#include <functional>
 
 #define USCXML_MONITOR_CATCH(callback) \
 catch (Event e) { LOG(USCXML_ERROR) << "Syntax error when calling " #callback " on monitors: " << std::endl << e << std::endl; } \

--- a/src/uscxml/plugins/Factory.cpp
+++ b/src/uscxml/plugins/Factory.cpp
@@ -612,7 +612,7 @@ Factory* Factory::getInstance() {
 #if 0
 	// this needs to be here as some plugins use xercesc, now in X::X in DOM.h
 	try {
-		::xercesc_3_1::XMLPlatformUtils::Initialize();
+		::XERCESC_NS::XMLPlatformUtils::Initialize();
 	} catch (const XERCESC_NS::XMLException& toCatch) {
 		ERROR_PLATFORM_THROW("Cannot initialize XercesC: " + X(toCatch.getMessage()).str());
 	}

--- a/src/uscxml/util/DOM.h
+++ b/src/uscxml/util/DOM.h
@@ -164,7 +164,7 @@ public :
 		// this is most unfortunate but needed with static XMLChars :(
 		if (!_xercesIsInit) {
 			try {
-				::xercesc_3_1::XMLPlatformUtils::Initialize();
+				::XERCESC_NS::XMLPlatformUtils::Initialize();
 				_xercesIsInit = true;
 			} catch (const XERCESC_NS::XMLException& toCatch) {
 				throw ("Cannot initialize XercesC: " + X(toCatch.getMessage()).str());

--- a/test/src/test-promela-parser.cpp
+++ b/test/src/test-promela-parser.cpp
@@ -321,7 +321,7 @@ void testPromelaParser() {
 
 int main(int argc, char** argv) {
 	try {
-		::xercesc_3_1::XMLPlatformUtils::Initialize();
+		::XERCESC_NS::XMLPlatformUtils::Initialize();
 	} catch (const XERCESC_NS::XMLException& toCatch) {
 		ERROR_PLATFORM_THROW("Cannot initialize XercesC: " + X(toCatch.getMessage()).str());
 	}

--- a/test/src/test-snippets.cpp
+++ b/test/src/test-snippets.cpp
@@ -39,13 +39,13 @@ void lambda_snippet() {
 
 	scxml.on().enterState([](const std::string& sessionId,
 	                         const std::string& stateName,
-	const xercesc_3_1::DOMElement* state) {
+	const XERCESC_NS::DOMElement* state) {
 		std::cout << "Entered " << stateName << std::endl;
 	});
 
 	scxml.on().exitState([](const std::string& sessionId,
 	                        const std::string& stateName,
-	const xercesc_3_1::DOMElement* state) {
+	const XERCESC_NS::DOMElement* state) {
 		std::cout << "Exited " << stateName << std::endl;
 	});
 


### PR DESCRIPTION
Adding fixes for building uSCXML on Bionic, which uses xerces version 3.2. Also fix a bug that causes compilation to fail on Bionic because of the missing <functional> header.