### PR TITLE
Only set _beforeEnteringState callback if "after" parameter is false

### DIFF
--- a/src/uscxml/interpreter/InterpreterMonitor.h
+++ b/src/uscxml/interpreter/InterpreterMonitor.h
@@ -211,7 +211,6 @@ public:
 	                                    const std::string& stateName,
 	                                    const XERCESC_NS::DOMElement* state)> callback,
 	                bool after = false) {
-		_beforeEnteringState = callback;
 		if (after) {
 			_afterEnteringState = callback;
 		} else {


### PR DESCRIPTION
...otherwise if after == "true" the callback will be called twice.