### PR TITLE
fix build lib version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,9 @@ else()
 	endif()
 endif()
 
+# Set option to let manuallu define XERCESC_NS
+set(XERCESC_NS "xercesc_3_1" CACHE STRING "Namespace for XercesC library")
+
 if (XercesC_FOUND)
     if(${XercesC_VERSION} VERSION_LESS "3.2")
 	    set(XERCESC_NS "xercesc_3_1")

--- a/contrib/python/bindings/test-state-pass.py
+++ b/contrib/python/bindings/test-state-pass.py
@@ -14,7 +14,7 @@ def main(argv):
     
     import uscxmlNativePython as uscxml
     
-    print "Processing" + argv[1]
+    print("Processing" + argv[1])
 
     interpreter = uscxml.Interpreter.fromURL(argv[1]);
     state = interpreter.step()

--- a/src/uscxml/Common.h
+++ b/src/uscxml/Common.h
@@ -20,10 +20,6 @@
 #ifndef COMMON_H_YZ3CIYP
 #define COMMON_H_YZ3CIYP
 
-#ifndef XERCESC_NS
-#define XERCESC_NS xercesc_3_1
-#endif
-
 #ifndef _MSC_VER
 #define ELPP_STACKTRACE_ON_CRASH 1
 #endif

--- a/src/uscxml/debug/InterpreterIssue.h
+++ b/src/uscxml/debug/InterpreterIssue.h
@@ -21,6 +21,7 @@
 #ifndef INTERPRETERISSUE_H_962CB305
 #define INTERPRETERISSUE_H_962CB305
 
+#include "uscxml/config.h"
 #include "uscxml/Common.h"
 
 #include <list>

--- a/src/uscxml/interpreter/BasicContentExecutor.cpp
+++ b/src/uscxml/interpreter/BasicContentExecutor.cpp
@@ -30,6 +30,7 @@
 #include <xercesc/framework/MemBufInputSource.hpp>
 
 #include "uscxml/interpreter/Logging.h"
+#include "uscxml/config.h"
 
 namespace uscxml {
 

--- a/src/uscxml/interpreter/BasicContentExecutor.h
+++ b/src/uscxml/interpreter/BasicContentExecutor.h
@@ -20,6 +20,7 @@
 #ifndef BASICCONTENTEXECUTOR_H_B873199D
 #define BASICCONTENTEXECUTOR_H_B873199D
 
+#include "uscxml/config.h"
 #include "ContentExecutorImpl.h"
 #include "uscxml/plugins/ExecutableContent.h"
 

--- a/src/uscxml/interpreter/InterpreterMonitor.h
+++ b/src/uscxml/interpreter/InterpreterMonitor.h
@@ -25,6 +25,7 @@
 #include "uscxml/interpreter/Logging.h"
 #include "uscxml/debug/InterpreterIssue.h"
 
+#include <functional>
 #include <mutex>
 #include <functional>
 

--- a/src/uscxml/messages/Data.h
+++ b/src/uscxml/messages/Data.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <type_traits>
 
+#include "uscxml/config.h"
 #include "uscxml/Common.h"
 #include "uscxml/util/Convenience.h"
 #include "uscxml/messages/Blob.h"

--- a/src/uscxml/plugins/ExecutableContent.h
+++ b/src/uscxml/plugins/ExecutableContent.h
@@ -20,6 +20,7 @@
 #ifndef EXECUTABLECONTENT_H_1E028A2D
 #define EXECUTABLECONTENT_H_1E028A2D
 
+#include "uscxml/config.h"
 #include "uscxml/Common.h"
 
 #include <string>

--- a/src/uscxml/util/DOM.h
+++ b/src/uscxml/util/DOM.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <string>
 
+#include "uscxml/config.h"
 #include "uscxml/Common.h"
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/dom/DOM.hpp>


### PR DESCRIPTION
Fix building on ubuntu 22.04.
build fail when building python binding is enabled (after swig installation).
Added include to config.h where requiring XERCESC_NS definition.
